### PR TITLE
Allow missing authentication method for overlay batch system

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class cobald(
   Boolean                    $multiplex_ssh              = true,                         # set up SSH multiplexing for cobald user (reduces latency of SSH logins)
   Boolean                    $ssh_perform_output_cleanup = false,                        # perform cleanup of job output files via SSH to ssh_hostname once per day
   String                     $output_cleanup_pattern     = 'slurm-*.out',                # pattern of files to delete when ssh_perform_output_cleanup is enabled
-  Optional[Enum['gsi']]      $auth_obs                   = 'gsi',                        # authentication used by overlay batch system
+  Optional[Enum['gsi']]      $auth_obs                   = undef,                        # authentication used by overlay batch system
   Boolean                    $manage_cas                 = false,                        # manage CAs (including CRLs)
   String                     $ca_repo_url                = $cobald::params::ca_repo_url, # repository URL from which to fetch CAs
   Array[String]              $ca_packages                = $cobald::params::ca_packages, # array containing names of CA packages

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -361,9 +361,6 @@ class cobald::install {
         }
       }
     }
-    default: {
-      fail("${module_name}: authentication method ${auth_obs} for overlay batch system not supported.")
-    }
   }
 
   if $cobald_version == 'master' or $tardis_version == 'master' {


### PR DESCRIPTION
First of all thanks for this module! 
In our setup, the overlay batch system runs locally, therefore (if I understand this correctly) we do not require authentication via `auth_obs`.
In this PR I've added a `none` switch which allows for bypassing the related section in `install.pp`. I don't know if this has other implications that I'm not aware of, as I currently can't test it because I first need to solve other unrelated problems ;)
It would be great if you could provide feedback to this PR. Feel free to reject it if it doesn't fit into the module.