### PR TITLE
Expose uid and gid of cobald user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,8 @@ class cobald(
   String                     $filename_cobald_robot_cert = undef,                        # cobald robot certificate file name (if OBS uses GSI authentication)
   Boolean                    $zabbix_monitor_robotcert   = false,                        # monitor validity of robot certificate via Zabbix
   Array[String]              $gsi_daemon_dns             = [],                           # distringuished names to be added to HTCondor variable GSI_DAEMON_NAME
+  Integer                    $uid                        = 509,                          # user id of cobald user
+  Integer                    $gid                        = 509,                          # group id of cobald user
 ) inherits cobald::params {
 
   Class { 'cobald::install': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,6 +36,8 @@ class cobald::install {
   $filename_cobald_robot_cert = $cobald::filename_cobald_robot_cert
   $zabbix_monitor_robotcert   = $cobald::zabbix_monitor_robotcert
   $gsi_daemon_dns             = $cobald::gsi_daemon_dns
+  $uid                        = $cobald::uid
+  $gid                        = $cobald::gid
 
   $cobald_url = $cobald_version ? {
     'master' => $::cobald::params::cobald_url, # use Github master branch
@@ -426,7 +428,10 @@ class cobald::install {
   }
 
   # Handle cobald user/group
-  class { 'cobald::user': }
+  class { 'cobald::user': 
+    uid => $uid,
+    gid => $gid,
+  }
 
   # Ensure directory for drone registry exists.
   # This is also used as cobald home directory.


### PR DESCRIPTION
This PR exposes `$uid` and `$gid` of `cobald::user` to the user. This was necessary because in our setup there already is a user with `uid` 509.