### PR TITLE
install: Create OpenSSL CSPRNG seed data for voms-proxy-init.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -319,6 +319,13 @@ class cobald::install {
         }
       }
 
+      exec { 'create random data for voms-proxy-init':
+        command => '/usr/bin/dd if=/dev/urandom of=/var/lib/cobald/.rnd bs=256 count=1',
+        user    => 'cobald',
+        require => File['/var/lib/cobald'],
+        creates => '/var/lib/cobald/.rnd',
+      }
+
       # Hourly refresh of proxy with a lifetime of 3 days
       # (make sure that starting jobs always have sufficient proxy lifetime)
       cron::hourly { 'cobald_refreshproxy':
@@ -329,6 +336,7 @@ class cobald::install {
           Package['voms-clients-cpp'],
           Class['fetchcrl'],
           File['/var/cache/cobald'],
+          Exec['create random data for voms-proxy-init'],
           Node_Encrypt::File['/etc/grid-security/robotcert.pem'],
           Node_Encrypt::File['/etc/grid-security/robotkey.pem'],
           User['cobald'],


### PR DESCRIPTION
voms-proxy-init tries to open ~/.rnd (via recent openssl libraries)
and if this does not exist, the error:
```
 Cannot open fileFilename=/var/lib/cobald/.rnd
 Function: RAND_load_file
```
is spammed into the cron log output. While it seems the data
is not actually used, best practice to silent the warnings
is to seed it with something useful as described here:
 https://security.stackexchange.com/a/177512

We observe this since the upgrade to CentOS 8. 