### PR TITLE
X.509 OBS auth: Only prolong proxy if needed, fix SELinux issue.

### DIFF
--- a/templates/pilot.jdl.epp
+++ b/templates/pilot.jdl.epp
@@ -13,7 +13,7 @@ log                     = /var/log/cobald/<%= $instance_name %>/pilots/$$(cluste
 JobBatchName            = <%= $vo %>-drone
 
 accounting_group        = <%= $vo %>
-x509userproxy           = /var/cache/cobald/proxy
+x509userproxy           = /var/run/condor/proxy
 
 environment             = ${Environment}
 


### PR DESCRIPTION
This changes proxy renewal to only recreate the proxy (72 hours lifetime)
if the remaining lifetime drops below 24 hours.
In addition, it is copied to */var/run/condor/proxy* which is now used
in the pilot JDLs for HTCondor local batch systems.

This significantly reduces the number of filetransfers into
HTCondor drones, and fixes an SELinux issue
(shadow needs to access the proxy).

~~Note: This is still marked WIP until properly tested ;-).~~