### PR TITLE
Drop ssh multiplexing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ file name of ssh private key used to access LBS (if ssh authentication is used t
 ##### `ssh_keytype` [`Enum['dsa', 'ecdsa', 'ed25519', 'rsa']`]
 type of ssh key used to access LBS (if ssh authentication is used to access LBS)
 
-##### `multiplex_ssh` [`Boolean`]
-Whether SSH multiplexing should be set up for the `cobald` user to reduce latency and improve reliability.
-
 ##### `ssh_perform_output_cleanup` [`Boolean`]
 Whether to perform cleanup of job output files via SSH to ssh_hostname once per day.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,6 @@ class cobald(
   Optional[String]           $ssh_hostkeytype            = undef,                        # encryption type of ssh host key (if ssh authentication is used to access LBS)
   Optional[String]           $ssh_privkey_filename       = undef,                        # file name of ssh private key used to access LBS (if ssh authentication is used to access LBS)
   Optional[Enum['dsa', 'ecdsa', 'ed25519', 'rsa']] $ssh_keytype    = undef,              # type of ssh key used to access LBS (if ssh authentication is used to access LBS)
-  Boolean                    $multiplex_ssh              = true,                         # set up SSH multiplexing for cobald user (reduces latency of SSH logins)
   Boolean                    $ssh_perform_output_cleanup = false,                        # perform cleanup of job output files via SSH to ssh_hostname once per day
   String                     $output_cleanup_pattern     = 'slurm-*.out',                # pattern of files to delete when ssh_perform_output_cleanup is enabled
   Optional[Enum['gsi']]      $auth_obs                   = undef,                        # authentication used by overlay batch system

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -214,6 +214,7 @@ class cobald::install {
           selrole  => 'object_r',
           seltype  => 'ssh_home_t',
           selrange => 's0',
+          require  => File['/var/lib/cobald'],
         }
         file { '/var/lib/cobald/.ssh/known_hosts':
           ensure   => 'file',
@@ -224,6 +225,7 @@ class cobald::install {
           selrole  => 'object_r',
           seltype  => 'ssh_home_t',
           selrange => 's0',
+          require  => File['/var/lib/cobald/.ssh'],
         }
         sshkey { $ssh_hostname:
           key      => $ssh_pubhostkey,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,6 @@ class cobald::install {
   $ssh_hostkeytype            = $cobald::ssh_hostkeytype
   $ssh_privkey_filename       = $cobald::ssh_privkey_filename
   $ssh_keytype                = $cobald::ssh_keytype
-  $multiplex_ssh              = $cobald::multiplex_ssh
   $ssh_perform_output_cleanup = $cobald::ssh_perform_output_cleanup
   $output_cleanup_pattern     = $cobald::output_cleanup_pattern
   $auth_obs                   = $cobald::auth_obs
@@ -215,7 +214,6 @@ class cobald::install {
           selrole  => 'object_r',
           seltype  => 'ssh_home_t',
           selrange => 's0',
-          require  => File['/var/lib/cobald'],
         }
         file { '/var/lib/cobald/.ssh/known_hosts':
           ensure   => 'file',
@@ -226,7 +224,6 @@ class cobald::install {
           selrole  => 'object_r',
           seltype  => 'ssh_home_t',
           selrange => 's0',
-          require  => File['/var/lib/cobald/.ssh'],
         }
         sshkey { $ssh_hostname:
           key      => $ssh_pubhostkey,
@@ -244,21 +241,6 @@ class cobald::install {
           selrange => 's0',
           content  => file($ssh_privkey_filename),
           require  => File['/var/lib/cobald/.ssh'],
-        }
-        if $multiplex_ssh {
-          ssh::client::config::user { 'cobald':
-            ensure  => present,
-            target  => '/var/lib/cobald/.ssh/config',
-            require => File['/var/lib/cobald/.ssh/known_hosts'],
-            options => {
-              "Host ${ssh_hostname}" => {
-                'ControlPath'         => '~/.ssh/master-%r@%h:%p',
-                'ControlMaster'       => 'auto',
-                'ControlPersist'      => '60',
-                'ServerAliveInterval' => '30',
-              }
-            }
-          }
         }
         cron::daily { 'cobald_cleanup_job_output_via_ssh':
           ensure  => bool2str($ssh_perform_output_cleanup, 'present', 'absent'),

--- a/metadata.json
+++ b/metadata.json
@@ -25,10 +25,6 @@
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "saz/ssh",
-      "version_requirement": ">= 6.0.0"
-    },
-    {
       "name": "puppet/cron",
       "version_requirement": ">= 2.0.0"
     },


### PR DESCRIPTION
We realized in MatterMiners/tardis#135 that this did not actually help, and a solution integrated into TARDIS was implemented in:
MatterMiners/tardis#145

This also drops the dependency on `saz/ssh`. 
Thanks to @giffels for spotting this :+1: . 