### PR TITLE
metadata: Fix misnamed dependency on voxpopuli/puppet-python.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/unibonn/puppet-cobald/issues",
   "dependencies": [
     {
-      "name": "voxpopuli/python",
+      "name": "puppet/python",
       "version_requirement": ">= 1.0.0"
     },
     {


### PR DESCRIPTION
The name from the metadata.json of the project has to be used,
usually with "-" replaced by "/", matching the path found
on the Puppet Forge.

fixes #10