### PR TITLE
Add proxy_{min,max}_lifetime_hours to configure proxy cert lifetime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ COBalD robot key file name (if OBS uses GSI authentication).
 ##### `filename_cobald_robot_cert` [`String`]
 COBalD robot certificate file name (if OBS uses GSI authentication).
 
+##### `proxy_min_lifetime_hours` [`Integer`]
+Minimum lifetime (hours) of proxy certificate created from COBalD robot (if OBS uses GSI authentication).
+
+##### `proxy_max_lifetime_hours` [`Integer`]
+Maximum lifetime (hours) of proxy certificate created from COBalD robot (if OBS uses GSI authentication).
+
 ##### `zabbix_monitor_robotcert` [`Boolean`]
 Add a Zabbix parameter (`robotcert.expiration_days`) to monitor the validity of the COBalD robot certificate (if OBS uses GSI authentication). Defaults to `false` to keep Zabbix an optional dependency.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,8 @@ class cobald(
   Array[String]              $ca_packages                = $cobald::params::ca_packages, # array containing names of CA packages
   String                     $filename_cobald_robot_key  = undef,                        # cobald robot key file name (if OBS uses GSI authentication)
   String                     $filename_cobald_robot_cert = undef,                        # cobald robot certificate file name (if OBS uses GSI authentication)
+  Integer[1,168]             $proxy_min_lifetime_hours   = 24,                           # minimum lifetime (hours) of proxy certificate created from cobald robot (if OBS uses GSI authentication)
+  Integer[2,168]             $proxy_max_lifetime_hours   = 72,                           # maximum lifetime (hours) of proxy certificate created from cobald robot (if OBS uses GSI authentication)
   Boolean                    $zabbix_monitor_robotcert   = false,                        # monitor validity of robot certificate via Zabbix
   Array[String]              $gsi_daemon_dns             = [],                           # distringuished names to be added to HTCondor variable GSI_DAEMON_NAME
   Integer                    $uid                        = 509,                          # user id of cobald user


### PR DESCRIPTION
Previously, a hardcoded lifetimes of 72 hours was used,
and a new proxy was created when the remaining lifetime dropped
below 24 hours. These values can now be configured.