### PR TITLE
metadata: Switch to puppet/systemd (voxpopuli).

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@
 # Copyright
 # ---------
 #
-# Copyright 2019-2021 University of Bonn
+# Copyright 2019-2022 University of Bonn
 #
 class cobald::install {
 

--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,8 @@
       "version_requirement": ">= 0.4.0 < 20.0.0"
     },
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 20.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.1.0 < 20.0.0"
     },
     {
       "name": "puppet/cron",


### PR DESCRIPTION
The `camptocamp` version has been donated to `voxpopuli` and is now deprecated.

fixes #14